### PR TITLE
Fix for Issue #4 -- MemoryChunks mockups reference Fabric '1' instead…

### DIFF
--- a/SC21-PoC/Chassis/1/MediaControllers/1/Ports/1/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/1/Ports/1/index.json
@@ -33,12 +33,12 @@
     "Links": {
         "ConnectedSwitches": [
             {
-                "@odata.id": "/redfish/v1/Fabrics/1/Switches/Switch1"
+                "@odata.id": "/redfish/v1/Fabrics/GenZ/Switches/Switch1"
             }
         ],
         "ConnectedPorts": [
             {
-                "@odata.id": "/redfish/v1/Fabrics/1/Switches/Switch1/Ports/7"
+                "@odata.id": "/redfish/v1/Fabrics/GenZ/Switches/Switch1/Ports/7"
             }
         ]
     },

--- a/SC21-PoC/Chassis/1/MediaControllers/1/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/1/index.json
@@ -26,7 +26,7 @@
     "Links": {
         "Endpoints": [
             {
-                "@odata.id": "/redfish/v1/Fabrics/1/Endpoints/7"
+                "@odata.id": "/redfish/v1/Fabrics/GenZ/Endpoints/7"
             }
         ],
         "MemoryDomains": [

--- a/SC21-PoC/Chassis/1/MediaControllers/2/Ports/1/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/2/Ports/1/index.json
@@ -33,12 +33,12 @@
     "Links": {
         "ConnectedSwitches": [
             {
-                "@odata.id": "/redfish/v1/Fabrics/1/Switches/Switch1"
+                "@odata.id": "/redfish/v1/Fabrics/GenZ/Switches/Switch1"
             }
         ],
         "ConnectedPorts": [
             {
-                "@odata.id": "/redfish/v1/Fabrics/1/Switches/Switch1/Ports/3"
+                "@odata.id": "/redfish/v1/Fabrics/GenZ/Switches/Switch1/Ports/3"
             }
         ]
     },

--- a/SC21-PoC/Chassis/1/MediaControllers/2/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/2/index.json
@@ -26,7 +26,7 @@
     "Links": {
         "Endpoints": [
             {
-                "@odata.id": "/redfish/v1/Fabrics/1/Endpoints/6"
+                "@odata.id": "/redfish/v1/Fabrics/GenZ/Endpoints/6"
             }
         ],
         "MemoryDomains": [

--- a/SC21-PoC/Chassis/1/MediaControllers/3/Ports/1/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/3/Ports/1/index.json
@@ -33,12 +33,12 @@
     "Links": {
         "ConnectedSwitches": [
             {
-                "@odata.id": "/redfish/v1/Fabrics/1/Switches/Switch1"
+                "@odata.id": "/redfish/v1/Fabrics/GenZ/Switches/Switch1"
             }
         ],
         "ConnectedPorts": [
             {
-                "@odata.id": "/redfish/v1/Fabrics/1/Switches/Switch1/Ports/5"
+                "@odata.id": "/redfish/v1/Fabrics/GenZ/Switches/Switch1/Ports/5"
             }
         ]
     },

--- a/SC21-PoC/Chassis/1/MediaControllers/3/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/3/index.json
@@ -26,7 +26,7 @@
     "Links": {
         "Endpoints": [
             {
-                "@odata.id": "/redfish/v1/Fabrics/1/Endpoints/3"
+                "@odata.id": "/redfish/v1/Fabrics/GenZ/Endpoints/3"
             }
         ],
         "MemoryDomains": [

--- a/SC21-PoC/Chassis/1/MediaControllers/4/Ports/1/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/4/Ports/1/index.json
@@ -33,12 +33,12 @@
     "Links": {
         "ConnectedSwitches": [
             {
-                "@odata.id": "/redfish/v1/Fabrics/1/Switches/Switch1"
+                "@odata.id": "/redfish/v1/Fabrics/GenZ/Switches/Switch1"
             }
         ],
         "ConnectedPorts": [
             {
-                "@odata.id": "/redfish/v1/Fabrics/1/Switches/Switch1/Ports/2"
+                "@odata.id": "/redfish/v1/Fabrics/GenZ/Switches/Switch1/Ports/2"
             }
         ]
     },

--- a/SC21-PoC/Chassis/1/MediaControllers/4/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/4/index.json
@@ -26,7 +26,7 @@
     "Links": {
         "Endpoints": [
             {
-                "@odata.id": "/redfish/v1/Fabrics/1/Endpoints/4"
+                "@odata.id": "/redfish/v1/Fabrics/GenZ/Endpoints/4"
             }
         ],
         "MemoryDomains": [

--- a/SC21-PoC/Chassis/1/MemoryDomains/1/MemoryChunks/1/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/1/MemoryChunks/1/index.json
@@ -33,7 +33,7 @@
     "Links": {
         "Endpoints": [
             {
-                "odata.id": "/redfish/v1/Fabrics/1/Endpoints/7"
+                "odata.id": "/redfish/v1/Fabrics/GenZ/Endpoints/7"
             }
         ]
     },

--- a/SC21-PoC/Chassis/1/MemoryDomains/1/MemoryChunks/2/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/1/MemoryChunks/2/index.json
@@ -33,7 +33,7 @@
     "Links": {
         "Endpoints": [
             {
-                "odata.id": "/redfish/v1/Fabrics/1/Endpoints/7"
+                "odata.id": "/redfish/v1/Fabrics/GenZ/Endpoints/7"
             }
         ]
     },

--- a/SC21-PoC/Chassis/1/MemoryDomains/2/MemoryChunks/1/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/2/MemoryChunks/1/index.json
@@ -33,7 +33,7 @@
     "Links": {
         "Endpoints": [
             {
-                "odata.id": "/redfish/v1/Fabrics/1/Endpoints/6"
+                "odata.id": "/redfish/v1/Fabrics/GenZ/Endpoints/6"
             }
         ]
     },

--- a/SC21-PoC/Chassis/1/MemoryDomains/2/MemoryChunks/2/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/2/MemoryChunks/2/index.json
@@ -33,7 +33,7 @@
     "Links": {
         "Endpoints": [
             {
-                "odata.id": "/redfish/v1/Fabrics/1/Endpoints/6"
+                "odata.id": "/redfish/v1/Fabrics/GenZ/Endpoints/6"
             }
         ]
     },

--- a/SC21-PoC/Chassis/1/MemoryDomains/3/MemoryChunks/1/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/3/MemoryChunks/1/index.json
@@ -33,7 +33,7 @@
     "Links": {
         "Endpoints": [
             {
-                "odata.id": "/redfish/v1/Fabrics/1/Endpoints/4"
+                "odata.id": "/redfish/v1/Fabrics/GenZ/Endpoints/4"
             }
         ]
     },

--- a/SC21-PoC/Chassis/1/MemoryDomains/3/MemoryChunks/2/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/3/MemoryChunks/2/index.json
@@ -33,7 +33,7 @@
     "Links": {
         "Endpoints": [
             {
-                "odata.id": "/redfish/v1/Fabrics/1/Endpoints/4"
+                "odata.id": "/redfish/v1/Fabrics/GenZ/Endpoints/4"
             }
         ]
     },

--- a/SC21-PoC/Chassis/1/MemoryDomains/4/MemoryChunks/1/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/4/MemoryChunks/1/index.json
@@ -33,7 +33,7 @@
     "Links": {
         "Endpoints": [
             {
-                "odata.id": "/redfish/v1/Fabrics/1/Endpoints/5"
+                "odata.id": "/redfish/v1/Fabrics/GenZ/Endpoints/5"
             }
         ]
     },

--- a/SC21-PoC/Chassis/1/MemoryDomains/4/MemoryChunks/2/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/4/MemoryChunks/2/index.json
@@ -33,7 +33,7 @@
     "Links": {
         "Endpoints": [
             {
-                "odata.id": "/redfish/v1/Fabrics/1/Endpoints/1"
+                "odata.id": "/redfish/v1/Fabrics/GenZ/Endpoints/1"
             }
         ]
     },


### PR DESCRIPTION
Fix #4 

Changed URI's to Fabrics/1 --> Fabrics/Gen-Z.  There were updates in MemoryDomain and MediaControllers.  