### PR TITLE
Fix for Issue #2 -- MemoryDomains Collection have wrong odata.ids

### DIFF
--- a/SC21-PoC/Chassis/1/MediaControllers/3/Ports/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/3/Ports/index.json
@@ -1,5 +1,5 @@
 {
-    "@odata.id": "/redfish/v1/Chassis/GenZ/MediaControllers/3/Ports",
+    "@odata.id": "/redfish/v1/Chassis/1/MediaControllers/3/Ports",
     "@odata.type": "#PortCollection.PortCollection",
     "Name": "Media Controller Port Collection",
     "Members@odata.count": 1,

--- a/SC21-PoC/Chassis/1/MediaControllers/4/Ports/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/4/Ports/index.json
@@ -4,9 +4,9 @@
     "Members@odata.count": 1,
     "Members": [
         {
-            "@odata.id": "/redfish/v1/Chassis/GenZ/MediaControllers/1/Ports/0"
+            "@odata.id": "/redfish/v1/Chassis/1/MediaControllers/1/Ports/0"
         }
     ],
-    "@odata.id": "/redfish/v1/Chassis/GenZ/MediaControllers/1/Ports",
+    "@odata.id": "/redfish/v1/Chassis/1/MediaControllers/1/Ports",
     "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/index.json
@@ -1,20 +1,20 @@
 {
-    "@odata.id": "/redfish/v1/Chassis/GenZ/MemoryDomains",
+    "@odata.id": "/redfish/v1/Chassis/1/MemoryDomains",
     "@odata.type": "#MemoryDomainCollection.MemoryDomainCollection",
     "Name": "Memory Domains Collection",
     "Members@odata.count": 4,
     "Members": [
         {
-            "@odata.id": "/redfish/v1/Chassis/GenZ/MemoryDomains/1"
+            "@odata.id": "/redfish/v1/Chassis/1/MemoryDomains/1"
         },
         {
-            "@odata.id": "/redfish/v1/Chassis/GenZ/MemoryDomains/2"
+            "@odata.id": "/redfish/v1/Chassis/1/MemoryDomains/2"
         },
         {
-            "@odata.id": "/redfish/v1/Chassis/GenZ/MemoryDomains/3"
+            "@odata.id": "/redfish/v1/Chassis/1/MemoryDomains/3"
         },
         {
-            "@odata.id": "/redfish/v1/Chassis/GenZ/MemoryDomains/4"
+            "@odata.id": "/redfish/v1/Chassis/1/MemoryDomains/4"
         }
     ],
     "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."


### PR DESCRIPTION
Fix #2 

Changed Chassis/GenZ --> Chassis/1 to have proper URIs.  Found this in MemoryDomains as well as MediaController Ports.  