### PR TITLE
Fix for issue #3:  Change copyright notices from DMTF to OFA

### DIFF
--- a/SC21-PoC/$metadata/index.xml
+++ b/SC21-PoC/$metadata/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright.-->
+<!-- Copyright 2021 OpenFabrics Alliance.  All rights reserve. -->
 <edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
 
   <edmx:Reference Uri="http://redfish.dmtf.org/schemas/swordfish/v1/Capacity_v1.xml">

--- a/SC21-PoC/Chassis/1/MediaControllers/1/Ports/1/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/1/Ports/1/index.json
@@ -43,5 +43,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MediaControllers/1/Ports/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/1/Ports/index.json
@@ -8,5 +8,5 @@
             "@odata.id": "/redfish/v1/Chassis/1/MediaControllers/1/Ports/1"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MediaControllers/1/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/1/index.json
@@ -36,5 +36,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MediaControllers/2/Ports/1/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/2/Ports/1/index.json
@@ -43,5 +43,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MediaControllers/2/Ports/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/2/Ports/index.json
@@ -8,5 +8,5 @@
             "@odata.id": "/redfish/v1/Chassis/1/MediaControllers/2/Ports/1"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MediaControllers/2/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/2/index.json
@@ -36,5 +36,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MediaControllers/3/Ports/1/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/3/Ports/1/index.json
@@ -43,5 +43,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MediaControllers/3/Ports/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/3/Ports/index.json
@@ -8,5 +8,5 @@
             "@odata.id": "/redfish/v1/Chassis/1/MediaControllers/3/Ports/1"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MediaControllers/3/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/3/index.json
@@ -36,5 +36,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MediaControllers/4/Ports/1/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/4/Ports/1/index.json
@@ -43,5 +43,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MediaControllers/4/Ports/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/4/Ports/index.json
@@ -8,5 +8,5 @@
         }
     ],
     "@odata.id": "/redfish/v1/Chassis/GenZ/MediaControllers/1/Ports",
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MediaControllers/4/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/4/index.json
@@ -36,5 +36,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MediaControllers/index.json
+++ b/SC21-PoC/Chassis/1/MediaControllers/index.json
@@ -17,5 +17,5 @@
             "@odata.id": "/redfish/v1/Chassis/1/MediaControllers/4"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/1/index.json
+++ b/SC21-PoC/Chassis/1/Memory/1/index.json
@@ -28,5 +28,5 @@
         "State": "Enabled"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/10/index.json
+++ b/SC21-PoC/Chassis/1/Memory/10/index.json
@@ -28,5 +28,5 @@
         "State": "Enabled"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/11/index.json
+++ b/SC21-PoC/Chassis/1/Memory/11/index.json
@@ -28,5 +28,5 @@
         "State": "Enabled"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/12/index.json
+++ b/SC21-PoC/Chassis/1/Memory/12/index.json
@@ -28,5 +28,5 @@
         "State": "Enabled"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/13/index.json
+++ b/SC21-PoC/Chassis/1/Memory/13/index.json
@@ -28,5 +28,5 @@
         "State": "Enabled"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/14/index.json
+++ b/SC21-PoC/Chassis/1/Memory/14/index.json
@@ -28,5 +28,5 @@
         "State": "Enabled"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/15/index.json
+++ b/SC21-PoC/Chassis/1/Memory/15/index.json
@@ -28,5 +28,5 @@
         "State": "Enabled"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/16/index.json
+++ b/SC21-PoC/Chassis/1/Memory/16/index.json
@@ -28,5 +28,5 @@
         "State": "Enabled"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/2/index.json
+++ b/SC21-PoC/Chassis/1/Memory/2/index.json
@@ -28,5 +28,5 @@
         "State": "Enabled"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/3/index.json
+++ b/SC21-PoC/Chassis/1/Memory/3/index.json
@@ -28,5 +28,5 @@
         "State": "Enabled"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/4/index.json
+++ b/SC21-PoC/Chassis/1/Memory/4/index.json
@@ -28,5 +28,5 @@
         "State": "Enabled"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/5/index.json
+++ b/SC21-PoC/Chassis/1/Memory/5/index.json
@@ -28,5 +28,5 @@
         "State": "Enabled"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/6/index.json
+++ b/SC21-PoC/Chassis/1/Memory/6/index.json
@@ -28,5 +28,5 @@
         "State": "Enabled"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/7/index.json
+++ b/SC21-PoC/Chassis/1/Memory/7/index.json
@@ -28,5 +28,5 @@
         "State": "Enabled"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/8/index.json
+++ b/SC21-PoC/Chassis/1/Memory/8/index.json
@@ -28,5 +28,5 @@
         "State": "Enabled"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/9/index.json
+++ b/SC21-PoC/Chassis/1/Memory/9/index.json
@@ -28,5 +28,5 @@
         "State": "Enabled"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/Memory/index.json
+++ b/SC21-PoC/Chassis/1/Memory/index.json
@@ -54,5 +54,5 @@
             "@odata.id": "/redfish/v1/Chassis/1/Memory/16"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/1/MemoryChunks/1/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/1/MemoryChunks/1/index.json
@@ -38,5 +38,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/1/MemoryChunks/2/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/1/MemoryChunks/2/index.json
@@ -38,5 +38,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/1/MemoryChunks/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/1/MemoryChunks/index.json
@@ -11,5 +11,5 @@
             "@odata.id": "/redfish/v1/Chassis/1/MemoryDomains/1/MemoryChunks/2"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/1/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/1/index.json
@@ -34,5 +34,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/2/MemoryChunks/1/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/2/MemoryChunks/1/index.json
@@ -38,5 +38,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/2/MemoryChunks/2/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/2/MemoryChunks/2/index.json
@@ -38,5 +38,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/2/MemoryChunks/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/2/MemoryChunks/index.json
@@ -11,5 +11,5 @@
             "@odata.id": "/redfish/v1/Chassis/1/MemoryDomains/2/MemoryChunks/2"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/2/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/2/index.json
@@ -34,5 +34,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/3/MemoryChunks/1/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/3/MemoryChunks/1/index.json
@@ -38,5 +38,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/3/MemoryChunks/2/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/3/MemoryChunks/2/index.json
@@ -38,5 +38,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/3/MemoryChunks/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/3/MemoryChunks/index.json
@@ -11,5 +11,5 @@
             "@odata.id": "/redfish/v1/Chassis/1/MemoryDomains/3/MemoryChunks/2"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/3/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/3/index.json
@@ -34,5 +34,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/4/MemoryChunks/1/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/4/MemoryChunks/1/index.json
@@ -38,5 +38,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/4/MemoryChunks/2/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/4/MemoryChunks/2/index.json
@@ -38,5 +38,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/4/MemoryChunks/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/4/MemoryChunks/index.json
@@ -11,5 +11,5 @@
             "@odata.id": "/redfish/v1/Chassis/1/MemoryDomains/4/MemoryChunks/2"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/4/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/4/index.json
@@ -34,5 +34,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/MemoryDomains/index.json
+++ b/SC21-PoC/Chassis/1/MemoryDomains/index.json
@@ -17,5 +17,5 @@
             "@odata.id": "/redfish/v1/Chassis/GenZ/MemoryDomains/4"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/1/index.json
+++ b/SC21-PoC/Chassis/1/index.json
@@ -46,5 +46,5 @@
         }
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Chassis/index.json
+++ b/SC21-PoC/Chassis/index.json
@@ -9,5 +9,5 @@
     }
 
   ],
-  "@Redfish.Copyright": "Copyright 2014-2020 SNIA. All rights reserved."
+  "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Connections/10/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Connections/10/index.json
@@ -52,5 +52,5 @@
             }
         ]
     },
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Connections/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Connections/index.json
@@ -8,5 +8,5 @@
             "@odata.id": "/redfish/v1/Fabrics/GenZ/Connections/10"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Endpoints/1/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Endpoints/1/index.json
@@ -47,5 +47,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Endpoints/2/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Endpoints/2/index.json
@@ -47,5 +47,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Endpoints/3/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Endpoints/3/index.json
@@ -47,5 +47,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Endpoints/4/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Endpoints/4/index.json
@@ -58,5 +58,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Endpoints/5/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Endpoints/5/index.json
@@ -58,5 +58,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Endpoints/6/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Endpoints/6/index.json
@@ -58,5 +58,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Endpoints/7/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Endpoints/7/index.json
@@ -58,5 +58,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Endpoints/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Endpoints/index.json
@@ -26,5 +26,5 @@
             "@odata.id": "/redfish/v1/Fabrics/GenZ/Endpoints/7"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Switches/Switch1/Ports/1/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Switches/Switch1/Ports/1/index.json
@@ -44,5 +44,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Switches/Switch1/Ports/2/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Switches/Switch1/Ports/2/index.json
@@ -44,5 +44,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Switches/Switch1/Ports/3/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Switches/Switch1/Ports/3/index.json
@@ -44,5 +44,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Switches/Switch1/Ports/4/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Switches/Switch1/Ports/4/index.json
@@ -44,5 +44,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Switches/Switch1/Ports/5/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Switches/Switch1/Ports/5/index.json
@@ -44,5 +44,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Switches/Switch1/Ports/6/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Switches/Switch1/Ports/6/index.json
@@ -44,5 +44,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Switches/Switch1/Ports/7/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Switches/Switch1/Ports/7/index.json
@@ -44,5 +44,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Switches/Switch1/Ports/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Switches/Switch1/Ports/index.json
@@ -27,5 +27,5 @@
         }
     ],
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Switches/Switch1/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Switches/Switch1/index.json
@@ -31,5 +31,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Switches/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Switches/index.json
@@ -9,5 +9,5 @@
         }
     ],
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Zones/0/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Zones/0/index.json
@@ -44,5 +44,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Zones/1/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Zones/1/index.json
@@ -31,5 +31,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Zones/2/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Zones/2/index.json
@@ -31,5 +31,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/Zones/index.json
+++ b/SC21-PoC/Fabrics/GenZ/Zones/index.json
@@ -15,5 +15,5 @@
         }
     ],
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/GenZ/index.json
+++ b/SC21-PoC/Fabrics/GenZ/index.json
@@ -22,5 +22,5 @@
         "@odata.id": "/redfish/v1/Fabrics/GenZ/Zones"
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Fabrics/index.json
+++ b/SC21-PoC/Fabrics/index.json
@@ -8,5 +8,5 @@
         }
     ],
     "@odata.id": "/redfish/v1/Fabrics",
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/EthernetInterfaces/1/SD/index.json
+++ b/SC21-PoC/Managers/1/EthernetInterfaces/1/SD/index.json
@@ -53,5 +53,5 @@
         "TheNameServer"
     ],
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/EthernetInterfaces/1/index.json
+++ b/SC21-PoC/Managers/1/EthernetInterfaces/1/index.json
@@ -135,5 +135,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/EthernetInterfaces/index.json
+++ b/SC21-PoC/Managers/1/EthernetInterfaces/index.json
@@ -10,5 +10,5 @@
         }
     ],
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/LogServices/LocalLogService/index.json
+++ b/SC21-PoC/Managers/1/LogServices/LocalLogService/index.json
@@ -21,5 +21,5 @@
         }
     ],
     "@odata.id": "/redfish/v1/Managers/1/LogServices/LocalLogService",
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/LogServices/Log1/Entries/1/index.json
+++ b/SC21-PoC/Managers/1/LogServices/Log1/Entries/1/index.json
@@ -19,5 +19,5 @@
     },
     "Oem": {},
     "@odata.id": "/redfish/v1/Managers/1/LogServices/Log1/Entries/1",
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/LogServices/Log1/Entries/index.json
+++ b/SC21-PoC/Managers/1/LogServices/Log1/Entries/index.json
@@ -28,5 +28,5 @@
         }
     ],
     "@odata.id": "/redfish/v1/Managers/1/LogServices/Log1/Entries",
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/LogServices/Log1/index.json
+++ b/SC21-PoC/Managers/1/LogServices/Log1/index.json
@@ -24,5 +24,5 @@
         "@odata.id": "/redfish/v1/Managers/1/LogServices/Log1/Entries"
     },
     "@odata.id": "/redfish/v1/Managers/1/LogServices/Log1",
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/LogServices/index.json
+++ b/SC21-PoC/Managers/1/LogServices/index.json
@@ -12,5 +12,5 @@
         }
     ],
     "@odata.id": "/redfish/v1/Managers/1/LogServices",
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/NetworkProtocol/HTTPS/Certificates/1/RekeyActionInfo/index.json
+++ b/SC21-PoC/Managers/1/NetworkProtocol/HTTPS/Certificates/1/RekeyActionInfo/index.json
@@ -30,5 +30,5 @@
     ],
     "Oem": {},
     "@odata.id": "/redfish/v1/Managers/1/NetworkProtocol/HTTPS/Certificates/1/RekeyActionInfo",
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/NetworkProtocol/HTTPS/Certificates/1/index.json
+++ b/SC21-PoC/Managers/1/NetworkProtocol/HTTPS/Certificates/1/index.json
@@ -41,5 +41,5 @@
     },
     "Oem": {},
     "@odata.id": "/redfish/v1/Managers/1/NetworkProtocol/HTTPS/Certificates/1",
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/NetworkProtocol/HTTPS/Certificates/index.json
+++ b/SC21-PoC/Managers/1/NetworkProtocol/HTTPS/Certificates/index.json
@@ -12,5 +12,5 @@
     ],
     "Oem": {},
     "@odata.id": "/redfish/v1/Managers/1/NetworkProtocol/HTTPS/Certificates",
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/NetworkProtocol/index.json
+++ b/SC21-PoC/Managers/1/NetworkProtocol/index.json
@@ -61,5 +61,5 @@
     },
     "Oem": {},
     "@odata.id": "/redfish/v1/Managers/1/NetworkProtocol",
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/SerialInterfaces/1/index.json
+++ b/SC21-PoC/Managers/1/SerialInterfaces/1/index.json
@@ -13,5 +13,5 @@
     "ConnectorType": "RJ45",
     "PinOut": "Cyclades",
     "@odata.id": "/redfish/v1/Managers/1/SerialInterfaces/1",
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/SerialInterfaces/index.json
+++ b/SC21-PoC/Managers/1/SerialInterfaces/index.json
@@ -10,5 +10,5 @@
     ],
     "Oem": {},
     "@odata.id": "/redfish/v1/Managers/1/SerialInterfaces",
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/USBPorts/1/index.json
+++ b/SC21-PoC/Managers/1/USBPorts/1/index.json
@@ -34,5 +34,5 @@
     "Links": {},
     "Oem": {},
     "@odata.id": "/redfish/v1/Managers/1/USBPorts/1",
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/USBPorts/index.json
+++ b/SC21-PoC/Managers/1/USBPorts/index.json
@@ -10,5 +10,5 @@
     ],
     "Oem": {},
     "@odata.id": "/redfish/v1/Managers/1/USBPorts",
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/1/index.json
+++ b/SC21-PoC/Managers/1/index.json
@@ -66,5 +66,5 @@
         "Oem": {}
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Managers/index.json
+++ b/SC21-PoC/Managers/index.json
@@ -8,5 +8,5 @@
         }
     ],
     "@odata.id": "/redfish/v1/Managers",
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Registries/AdvertisedFeatures.v1_0_0.json
+++ b/SC21-PoC/Registries/AdvertisedFeatures.v1_0_0.json
@@ -16,5 +16,5 @@
       "CorrespondingProfileDefinition": "SwordfishNVMeDriveEthernetAttach.json"
     }
   ],
-  "@Redfish.Copyright": "Copyright 2019-2021 SNIA. All rights reserved."
+  "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Registries/AdvertisedFeatures.v1_0_0/index.json
+++ b/SC21-PoC/Registries/AdvertisedFeatures.v1_0_0/index.json
@@ -1,5 +1,5 @@
 {
-  "@Redfish.Copyright": "Copyright 2014-2020 SNIA. All rights reserved.",
+  "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
   "@odata.id": "/redfish/v1/Registries/AdvertisedFeatures.v1_0_0",
   "@odata.type": "#MessageRegistryFile.v1_1_3.MessageRegistryFile",
   "Id": "AdvertisedFeatures.v1_0_0",

--- a/SC21-PoC/Registries/index.json
+++ b/SC21-PoC/Registries/index.json
@@ -1,5 +1,5 @@
 {
-  "@Redfish.Copyright": "Copyright 2014-2020 SNIA. All rights reserved.",
+  "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
   "@odata.id": "/redfish/v1/Registries",
   "@odata.type": "#MessageRegistryFileCollection.MessageRegistryFileCollection",
   "Name": "Registry File Collection",

--- a/SC21-PoC/SessionService/Sessions/1234567890ABCDEF/index.json
+++ b/SC21-PoC/SessionService/Sessions/1234567890ABCDEF/index.json
@@ -5,5 +5,5 @@
   "Description": "Manager User Session",
   "UserName": "Administrator",
   "@odata.id": "/redfish/v1/SessionService/Sessions/1234567890ABCDEF",
-  "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+  "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/SessionService/Sessions/index.json
+++ b/SC21-PoC/SessionService/Sessions/index.json
@@ -8,5 +8,5 @@
     }
   ],
   "@odata.id": "/redfish/v1/SessionService/Sessions",
-  "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+  "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/SessionService/index.json
+++ b/SC21-PoC/SessionService/index.json
@@ -13,5 +13,5 @@
     "@odata.id": "/redfish/v1/SessionService/Sessions"
   },
   "@odata.id": "/redfish/v1/SessionService",
-  "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+  "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Storage/IPAttachedDrive/Controllers/NVMeIOController/index.json
+++ b/SC21-PoC/Storage/IPAttachedDrive/Controllers/NVMeIOController/index.json
@@ -1,5 +1,5 @@
 {
-  "@Redfish.Copyright": "Copyright 2014-2020 SNIA. All rights reserved.",
+  "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
   "@odata.id": "/redfish/v1/Storage/IPAttachedDrive/Controllers/NVMeIOController",
   "@odata.type": "#StorageController.v1_1_0.StorageController",
   "Id": "NVMeIOController",

--- a/SC21-PoC/Storage/IPAttachedDrive/Controllers/index.json
+++ b/SC21-PoC/Storage/IPAttachedDrive/Controllers/index.json
@@ -9,5 +9,5 @@
     }
   ],
   "@odata.id": "/redfish/v1/Storage/IPAttachedDrive/Controllers",
-  "@Redfish.Copyright": "Copyright 2020 SNIA. All rights reserved."
+  "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Storage/IPAttachedDrive/Volumes/SimpleNamespace/index.json
+++ b/SC21-PoC/Storage/IPAttachedDrive/Volumes/SimpleNamespace/index.json
@@ -1,5 +1,5 @@
 {
-  "@Redfish.Copyright": "Copyright 2014-2020 SNIA. All rights reserved.",
+  "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
   "@odata.id": "/redfish/v1/Storage/IPAttachedDrive/Volumes/SimpleNamespace",
   "@odata.type": "#Volume.v1_5_0.Volume",
   "Id": "1",

--- a/SC21-PoC/Storage/IPAttachedDrive/Volumes/index.json
+++ b/SC21-PoC/Storage/IPAttachedDrive/Volumes/index.json
@@ -10,5 +10,5 @@
   ],
   "Oem": {},
   "@odata.id": "/redfish/v1/Storage/IPAttachedDrive/Volumes",
-  "@Redfish.Copyright": "Copyright 2014-2020 SNIA. All rights reserved."
+  "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Storage/IPAttachedDrive/index.json
+++ b/SC21-PoC/Storage/IPAttachedDrive/index.json
@@ -1,5 +1,5 @@
 {
-  "@Redfish.Copyright": "Copyright 2014-2020 SNIA. All rights reserved.",
+  "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
   "@odata.id": "/redfish/v1/Storage/IPAttachedDrive",
   "@odata.type": "#Storage.v1_10_0.Storage",
   "Id": "1",

--- a/SC21-PoC/Storage/index.json
+++ b/SC21-PoC/Storage/index.json
@@ -8,5 +8,5 @@
     }
   ],
   "@odata.id": "/redfish/v1/Storage",
-  "@Redfish.Copyright": "Copyright 2014-2020 SNIA. All rights reserved."
+  "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Systems/1/FabricAdapters/1/Ports/1/index.json
+++ b/SC21-PoC/Systems/1/FabricAdapters/1/Ports/1/index.json
@@ -57,5 +57,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Systems/1/FabricAdapters/1/Ports/2/index.json
+++ b/SC21-PoC/Systems/1/FabricAdapters/1/Ports/2/index.json
@@ -54,5 +54,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Systems/1/FabricAdapters/1/Ports/index.json
+++ b/SC21-PoC/Systems/1/FabricAdapters/1/Ports/index.json
@@ -11,5 +11,5 @@
             "@odata.id": "/redfish/v1/Systems/1/FabricAdapters/1/Ports/2"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Systems/1/FabricAdapters/1/index.json
+++ b/SC21-PoC/Systems/1/FabricAdapters/1/index.json
@@ -101,5 +101,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Systems/1/FabricAdapters/index.json
+++ b/SC21-PoC/Systems/1/FabricAdapters/index.json
@@ -8,5 +8,5 @@
             "@odata.id": "/redfish/v1/Systems/1/FabricAdapters/1"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Systems/2/FabricAdapters/1/Ports/1/index.json
+++ b/SC21-PoC/Systems/2/FabricAdapters/1/Ports/1/index.json
@@ -57,5 +57,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Systems/2/FabricAdapters/1/Ports/2/index.json
+++ b/SC21-PoC/Systems/2/FabricAdapters/1/Ports/2/index.json
@@ -54,5 +54,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Systems/2/FabricAdapters/1/Ports/index.json
+++ b/SC21-PoC/Systems/2/FabricAdapters/1/Ports/index.json
@@ -11,5 +11,5 @@
             "@odata.id": "/redfish/v1/Systems/2/FabricAdapters/1/Ports/2"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Systems/2/FabricAdapters/1/index.json
+++ b/SC21-PoC/Systems/2/FabricAdapters/1/index.json
@@ -101,5 +101,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Systems/2/FabricAdapters/index.json
+++ b/SC21-PoC/Systems/2/FabricAdapters/index.json
@@ -8,5 +8,5 @@
             "@odata.id": "/redfish/v1/Systems/2/FabricAdapters/1"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Systems/FM/FabricAdapters/1/Ports/1/index.json
+++ b/SC21-PoC/Systems/FM/FabricAdapters/1/Ports/1/index.json
@@ -57,5 +57,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Systems/FM/FabricAdapters/1/Ports/2/index.json
+++ b/SC21-PoC/Systems/FM/FabricAdapters/1/Ports/2/index.json
@@ -54,5 +54,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Systems/FM/FabricAdapters/1/Ports/index.json
+++ b/SC21-PoC/Systems/FM/FabricAdapters/1/Ports/index.json
@@ -11,5 +11,5 @@
             "@odata.id": "/redfish/v1/Systems/FM/FabricAdapters/1/Ports/2"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Systems/FM/FabricAdapters/1/index.json
+++ b/SC21-PoC/Systems/FM/FabricAdapters/1/index.json
@@ -101,5 +101,5 @@
         ]
     },
     "Oem": {},
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/Systems/FM/FabricAdapters/index.json
+++ b/SC21-PoC/Systems/FM/FabricAdapters/index.json
@@ -8,5 +8,5 @@
             "@odata.id": "/redfish/v1/Systems/FM/FabricAdapters/1"
         }
     ],
-    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+    "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved."
 }

--- a/SC21-PoC/index.json
+++ b/SC21-PoC/index.json
@@ -1,5 +1,5 @@
 {
-  "@Redfish.Copyright": "Copyright 2014-2021 SNIA. All rights reserved.",
+  "@Redfish.Copyright": "Copyright 2021 OpenFabrics Alliance. All rights reserved.",
   "@odata.id": "/redfish/v1/",
   "@odata.type": "#ServiceRoot.v1_9_0.ServiceRoot",
   "Id": "RootService",


### PR DESCRIPTION
Fix #3 

Changed all Redfish.Copyright lines to "Copyright 2021 OpenFabrics Alliance.  All rights reserved."

