### PR TITLE
Added missing CXL-Chassis

### DIFF
--- a/SC22-PoC/Chassis/CXL-Chassis/index.json
+++ b/SC22-PoC/Chassis/CXL-Chassis/index.json
@@ -1,0 +1,21 @@
+{
+    "@odata.type": "#Chassis.v1_21_0.Chassis",
+    "Id": "CXL-Chassis",
+    "Name": "CXL Computer System chassis",
+    "PowerState": "On",
+    "ChassisType": "Drawer",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK",
+        "HealthRollup": "OK"
+    },
+    "Links": {
+        "ComputerSystems": [
+            {
+                "@odata.id" : "/redfish/v1/Systems/CXL-System"
+            }
+        ]
+    },
+    "@odata.id": "/redfish/v1/Chassis/CXL-Chassis",
+    "@Redfish.Copyright": "Copyright 2022 OpenFabrics Alliance. All rights reserved."
+}


### PR DESCRIPTION
Added missing CXL-Chassis description. This chassis is linked to the CXL-System computer system.

Signed-off-by: Christian Pinto <christian.pinto@ibm.com>